### PR TITLE
[FLINK-2435] [EPMOSBD-179] added support of generified types;

### DIFF
--- a/flink-java/src/main/java/org/apache/flink/api/java/io/CsvReader.java
+++ b/flink-java/src/main/java/org/apache/flink/api/java/io/CsvReader.java
@@ -478,11 +478,31 @@ public class CsvReader {
 	/**
 	 * Configures the reader to read the CSV data and parse it to the {@link org.apache.flink.types.Row} type.
 	 * The type information for the fields is obtained from the type information.
+	 * This method is created to overcome limitations of the types() method, which loose Generics information
+	 * during runtime. With this method it is possible to use {@link TypeHint} power to instruct the engine about concrete
+	 * field types, e.g.
+	 * <pre>
+	 * {@code
+	 *
+	 * ParserFactory<CustomType<NestedCustomType>> factory = new ParserFactory<CustomType<NestedCustomType>>{...}
+	 * TypeHint<CustomType<NestedCustomType>> typeHint = new TypeHint<CustomType<NestedCustomType>>() {};
+	 * TypeInformation<CustomType<NestedCustomType>> typeInfo = TypeInformation.of(customTypeInstruction);
+	 *
+	 * FieldParser.registerCustomParser(typeInfo.getTypeClass(), factory);
+	 *
+	 * DataSource<Row> csvDataSource = csvReader.preciseRowType(
+	 *   BasicTypeInfo.INT_TYPE_INFO,
+	 *   BasicTypeInfo.STRING_TYPE_INFO,
+	 *   typeInfo
+	 * );
+	 * csvDataSource.print();
+	 * }
+	 * </pre>
 	 *
 	 * @param rowFieldsTypeInformation The fields types information which are mapped to CSV fields.
 	 * @return The DataSet representing the parsed CSV data.
 	 */
-	private DataSource<Row> preciseRowType(TypeInformation<?>... rowFieldsTypeInformation) {
+	public DataSource<Row> preciseRowType(TypeInformation<?>... rowFieldsTypeInformation) {
 		if (rowFieldsTypeInformation == null || rowFieldsTypeInformation.length == 0) {
 			throw new IllegalArgumentException("Row fields type information must not be null or empty.");
 		}

--- a/flink-tests/src/test/java/org/apache/flink/test/io/CsvReaderCustomGenericsAwareRowTupleIT.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/io/CsvReaderCustomGenericsAwareRowTupleIT.java
@@ -18,7 +18,6 @@
 
 package org.apache.flink.test.io;
 
-import com.fasterxml.jackson.core.type.TypeReference;
 import org.apache.flink.api.common.typeinfo.BasicTypeInfo;
 import org.apache.flink.api.common.typeinfo.TypeHint;
 import org.apache.flink.api.common.typeinfo.TypeInformation;
@@ -30,6 +29,8 @@ import org.apache.flink.types.IntValue;
 import org.apache.flink.types.StringValue;
 import org.apache.flink.types.parser.FieldParser;
 import org.apache.flink.types.parser.ParserFactory;
+
+import com.fasterxml.jackson.core.type.TypeReference;
 import org.junit.Test;
 
 /**
@@ -42,7 +43,6 @@ public class CsvReaderCustomGenericsAwareRowTupleIT extends CsvReaderCustomTypeT
 	public CsvReaderCustomGenericsAwareRowTupleIT(TestExecutionMode mode) {
 		super(mode);
 	}
-
 
 	@Test
 	public void testCustomGenericsAwareRowTypeViaRowTypeMethod() throws Exception {

--- a/flink-tests/src/test/java/org/apache/flink/test/io/CsvReaderCustomGenericsAwareRowTupleIT.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/io/CsvReaderCustomGenericsAwareRowTupleIT.java
@@ -1,0 +1,124 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.test.io;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+import org.apache.flink.api.common.typeinfo.BasicTypeInfo;
+import org.apache.flink.api.common.typeinfo.TypeHint;
+import org.apache.flink.api.common.typeinfo.TypeInformation;
+import org.apache.flink.api.java.ExecutionEnvironment;
+import org.apache.flink.api.java.io.CsvReader;
+import org.apache.flink.test.io.csv.custom.type.NestedCustomJsonType;
+import org.apache.flink.test.io.csv.custom.type.complex.GenericsAwareCustomJsonType;
+import org.apache.flink.types.IntValue;
+import org.apache.flink.types.StringValue;
+import org.apache.flink.types.parser.FieldParser;
+import org.apache.flink.types.parser.ParserFactory;
+import org.junit.Test;
+
+/**
+ * A collection of tests for checking different approaches of operating over user-defined Row types,
+ * utilizing newly introduced CsvReader methods.
+ * his class is aimed to verify use cases of classes with Java Generics.
+ */
+public class CsvReaderCustomGenericsAwareRowTupleIT extends CsvReaderCustomTypeTest {
+
+	public CsvReaderCustomGenericsAwareRowTupleIT(TestExecutionMode mode) {
+		super(mode);
+	}
+
+
+	@Test
+	public void testCustomGenericsAwareRowTypeViaRowTypeMethod() throws Exception {
+		givenCsvSourceData("1,'column2','{\"f1\":5, \"f2\": {\"f21\":\"nested_simple_f21\"}, \"f3\": {\"f21\":\"nested_generic_f31\"}}'\n");
+		givenCsvReaderConfigured();
+
+		whenCustomTypesAreRegisteredAlongWithTheirParsers();
+		whenDataSourceCreatedViaRowTypeMethod();
+		whenProcessingExecutedToCollectResultTuples();
+
+		thenResultingTupleHasExpectedHierarchyAndFieldValues();
+	}
+
+	@Test
+	public void testCustomGenericsAwareRowTypeViaPreciseRowTypeMethod() throws Exception {
+		givenCsvSourceData("1,'column2','{\"f1\":5, \"f2\": {\"f21\":\"nested_simple_f21\"}, \"f3\": {\"f21\":\"nested_generic_f31\"}}'\n");
+		givenCsvReaderConfigured();
+
+		whenCustomTypesAreRegisteredAlongWithTheirParsers();
+		whenDataSourceCreatedViaPreciseRowTypeMethod();
+		whenProcessingExecutedToCollectResultTuples();
+
+		thenResultingTupleHasExpectedHierarchyAndFieldValues();
+	}
+
+	private void givenCsvSourceData(String sourceData) {
+		context.sourceData = sourceData;
+	}
+
+	private void givenCsvReaderConfigured() throws Exception {
+		final String dataPath = createInputData(tempFolder, context.sourceData);
+		final ExecutionEnvironment env = ExecutionEnvironment.getExecutionEnvironment();
+		CsvReader reader = env.readCsvFile(dataPath);
+		reader.fieldDelimiter(",");
+		reader.parseQuotedStrings('\'');
+		context.reader = reader;
+	}
+
+	private void whenCustomTypesAreRegisteredAlongWithTheirParsers() {
+		ParserFactory<NestedCustomJsonType> factoryForNestedCustomType = new NestedCustomJsonParserFactory();
+		FieldParser.registerCustomParser(NestedCustomJsonType.class, factoryForNestedCustomType);
+
+		TypeHint<GenericsAwareCustomJsonType<NestedCustomJsonType>> typeHint = new TypeHint<GenericsAwareCustomJsonType<NestedCustomJsonType>>() {
+		};
+		TypeInformation<GenericsAwareCustomJsonType<NestedCustomJsonType>> typeInfo = TypeInformation.of(typeHint);
+		Class<GenericsAwareCustomJsonType<NestedCustomJsonType>> type = typeInfo.getTypeClass();
+
+		ParserFactory<GenericsAwareCustomJsonType<NestedCustomJsonType>> factoryForGenericType = new GenericsAwareCustomJsonParserFactory<>(
+			new TypeReference<GenericsAwareCustomJsonType<NestedCustomJsonType>>() {
+			}
+		);
+		FieldParser.registerCustomParser(type, factoryForGenericType);
+	}
+
+	private void whenDataSourceCreatedViaRowTypeMethod() {
+		context.dataSource = context.reader.rowType(IntValue.class, StringValue.class, GenericsAwareCustomJsonType.class);
+	}
+
+	private void whenDataSourceCreatedViaPreciseRowTypeMethod() {
+		context.dataSource = context.reader.preciseRowType(
+			BasicTypeInfo.INT_TYPE_INFO,
+			BasicTypeInfo.STRING_TYPE_INFO,
+			TypeInformation.of(new TypeHint<GenericsAwareCustomJsonType<NestedCustomJsonType>>() {
+			})
+		);
+	}
+
+	private void whenProcessingExecutedToCollectResultTuples() throws Exception {
+		context.result = context.dataSource.collect();
+	}
+
+	private void thenResultingTupleHasExpectedHierarchyAndFieldValues() {
+		compareResultAsText(
+			context.result,
+			"1,column2,GenericsAwareCustomJsonType{f1='5', f2=NestedCustomJsonType{f21='nested_simple_f21'}, f3=NestedCustomJsonType{f21='nested_generic_f31'}}"
+		);
+	}
+
+}

--- a/flink-tests/src/test/java/org/apache/flink/test/io/CsvReaderITCase.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/io/CsvReaderITCase.java
@@ -173,6 +173,24 @@ public class CsvReaderITCase extends MultipleProgramsTestBase {
 		env.readCsvFile(dataPath).rowType();
 	}
 
+	@Test(expected = IllegalArgumentException.class)
+	public void testPreciseRowTypeWithNullFieldTypes() throws Exception {
+		final String inputData = "ABC,true,1,2,3,4,5.0,6.0\nBCD,false,1,2,3,4,5.0,6.0";
+		final String dataPath = createInputData(tempFolder, inputData);
+		final ExecutionEnvironment env = ExecutionEnvironment.getExecutionEnvironment();
+
+		env.readCsvFile(dataPath).preciseRowType(null);
+	}
+
+	@Test(expected = IllegalArgumentException.class)
+	public void testPreciseRowTypeWithEmptyFieldType() throws Exception {
+		final String inputData = "ABC,true,1,2,3,4,5.0,6.0\nBCD,false,1,2,3,4,5.0,6.0";
+		final String dataPath = createInputData(tempFolder, inputData);
+		final ExecutionEnvironment env = ExecutionEnvironment.getExecutionEnvironment();
+
+		env.readCsvFile(dataPath).preciseRowType();
+	}
+
 	/**
 	 * POJO.
 	 */


### PR DESCRIPTION
- method preciseRowType() is open now;
- added javaDoc to preciseRowType() method;
- added test for generified types;


*Thank you very much for contributing to Apache Flink - we are happy that you want to help us improve Flink. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

*Please understand that we do not do this to make contributions to Flink a hassle. In order to uphold a high standard of quality for code contributions, while at the same time managing a large number of contributions, we need contributors to prepare the contributions well, and give reviewers enough contextual information for the review. Please also understand that contributions that do not follow this guide will take longer to review and thus typically be picked up with lower priority by the community.*

## Contribution Checklist

  - Make sure that the pull request corresponds to a [JIRA issue](https://issues.apache.org/jira/projects/FLINK/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no JIRA issue.
  
  - Name the pull request in the form "[FLINK-XXXX] [component] Title of the pull request", where *FLINK-XXXX* should be replaced by the actual issue number. Skip *component* if you are unsure about which is the best component.
  Typo fixes that have no associated JIRA issue should be named following this pattern: `[hotfix] [docs] Fix typo in event time introduction` or `[hotfix] [javadocs] Expand JavaDoc for PuncuatedWatermarkGenerator`.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Make sure that the change passes the automated tests, i.e., `mvn clean verify` passes. You can set up Travis CI to do that following [this guide](http://flink.apache.org/contribute-code.html#best-practices).

  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message (including the JIRA id)

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.


**(The sections below can be removed for hotfixes of typos)**

## What is the purpose of the change

*(For example: This pull request makes task deployment go through the blob server, rather than through RPC. That way we avoid re-transferring them on each deployment (during recovery).)*


## Brief change log

*(for example:)*
  - *The TaskInfo is stored in the blob store on job creation time as a persistent artifact*
  - *Deployments RPC transmits only the blob storage reference*
  - *TaskManagers retrieve the TaskInfo from the blob cache*


## Verifying this change

*(Please pick either of the following options)*

This change is a trivial rework / code cleanup without any test coverage.

*(or)*

This change is already covered by existing tests, such as *(please describe tests)*.

*(or)*

This change added tests and can be verified as follows:

*(example:)*
  - *Added integration tests for end-to-end deployment with large payloads (100MB)*
  - *Extended integration test for recovery after master (JobManager) failure*
  - *Added test that validates that TaskInfo is transferred only once across recoveries*
  - *Manually verified the change by running a 4 node cluser with 2 JobManagers and 4 TaskManagers, a stateful streaming program, and killing one JobManager and two TaskManagers during the execution, verifying that recovery happens correctly.*

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / no)
  - The serializers: (yes / no / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / no / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (yes / no / don't know)
  - The S3 file system connector: (yes / no / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / no)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
